### PR TITLE
feat(front): UI/레이아웃 공통 컴포넌트 MD3 테마 마이그레이션

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ npm run preview   # 프로덕션 빌드 미리보기
 - `AuthLayout` — 중앙 정렬 카드 레이아웃 (로그인/회원가입)
 - `ProtectedRoute` — 미인증 사용자 리다이렉트
 
-**스타일링:** `front/src/index.css`에서 `@theme`(Tailwind v4 문법)으로 정의된 커스텀 색상 토큰의 다크 테마. 주요 색상: `primary` (#6366f1 인디고), `surface` (#1e1b2e), `background` (#0f0d1a). 조건부 클래스에 `clsx` 사용.
+**스타일링:** `front/src/index.css`에서 `@theme`(Tailwind v4 문법)으로 정의된 MD3(Material Design 3) 색상 토큰 기반 다크 테마. 주요 토큰: `primary`/`primary-container`(인디고 계열), `surface`/`surface-container`/`surface-container-high`/`surface-container-highest`(배경 계층), `on-surface`/`on-surface-variant`(텍스트), `outline`/`outline-variant`(보조 텍스트/테두리), `tertiary`(강조), `error`/`success`/`warning`/`info`(상태). 조건부 클래스에 `clsx` 사용.
 
 **차트:** recharts 라이브러리로 통계 시각화 (장르 바 차트, 평점 히스토그램, 월별 히스토리, 탑 스튜디오).
 

--- a/front/src/components/layout/AuthLayout.tsx
+++ b/front/src/components/layout/AuthLayout.tsx
@@ -2,9 +2,9 @@ import { Outlet, Link } from 'react-router';
 
 export function AuthLayout() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-surface px-4">
       <Link to="/" className="mb-8">
-        <span className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+        <span className="text-3xl font-bold bg-gradient-to-r from-primary to-tertiary bg-clip-text text-transparent">
           AniRec
         </span>
       </Link>

--- a/front/src/components/layout/Footer.tsx
+++ b/front/src/components/layout/Footer.tsx
@@ -2,13 +2,13 @@ import { Heart } from 'lucide-react';
 
 export function Footer() {
   return (
-    <footer className="border-t border-surface-lighter bg-surface/50 mt-auto">
+    <footer className="border-t border-outline-variant bg-surface-container/50 mt-auto">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex flex-col md:flex-row items-center justify-between gap-4">
-          <div className="text-sm text-text-muted">
+          <div className="text-sm text-outline">
             &copy; {new Date().getFullYear()} AniRec. Built for anime fans.
           </div>
-          <div className="flex items-center gap-1 text-sm text-text-muted">
+          <div className="flex items-center gap-1 text-sm text-outline">
             Made with <Heart size={14} className="text-error fill-error" /> using MAL data
           </div>
         </div>

--- a/front/src/components/layout/Navbar.tsx
+++ b/front/src/components/layout/Navbar.tsx
@@ -21,11 +21,11 @@ export function Navbar() {
   const visibleLinks = navLinks.filter(link => !link.auth || isAuthenticated);
 
   return (
-    <nav className="sticky top-0 z-40 bg-surface/80 backdrop-blur-xl border-b border-surface-lighter">
+    <nav className="sticky top-0 z-40 bg-surface-container/80 backdrop-blur-xl border-b border-outline-variant">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <Link to="/" className="flex items-center gap-2">
-            <span className="text-2xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+            <span className="text-2xl font-bold bg-gradient-to-r from-primary to-tertiary bg-clip-text text-transparent">
               AniRec
             </span>
           </Link>
@@ -37,8 +37,8 @@ export function Navbar() {
                 to={link.to}
                 className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                   location.pathname === link.to
-                    ? 'bg-primary/10 text-primary-light'
-                    : 'text-text-secondary hover:text-text-primary hover:bg-surface-light'
+                    ? 'bg-primary-container text-on-primary-container'
+                    : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'
                 }`}
               >
                 {link.label}
@@ -53,11 +53,11 @@ export function Navbar() {
               <div className="flex items-center gap-3">
                 <div className="flex items-center gap-2">
                   <Avatar name={user?.username ?? ''} size="sm" />
-                  <span className="text-sm text-text-secondary">{user?.username}</span>
+                  <span className="text-sm text-on-surface-variant">{user?.username}</span>
                 </div>
                 <button
                   onClick={logout}
-                  className="p-2 rounded-lg hover:bg-surface-light text-text-muted hover:text-text-primary transition-colors"
+                  className="p-2 rounded-lg hover:bg-surface-container-high text-outline hover:text-on-surface transition-colors"
                   title="Logout"
                 >
                   <LogOut size={18} />
@@ -76,7 +76,7 @@ export function Navbar() {
           </div>
 
           <button
-            className="md:hidden p-2 rounded-lg hover:bg-surface-light text-text-secondary"
+            className="md:hidden p-2 rounded-lg hover:bg-surface-container-high text-on-surface-variant"
             onClick={() => setMobileOpen(!mobileOpen)}
           >
             {mobileOpen ? <X size={24} /> : <Menu size={24} />}
@@ -84,7 +84,7 @@ export function Navbar() {
         </div>
 
         {mobileOpen && (
-          <div className="md:hidden pb-4 border-t border-surface-lighter mt-2 pt-4">
+          <div className="md:hidden pb-4 border-t border-outline-variant mt-2 pt-4">
             <div className="flex flex-col gap-1">
               {visibleLinks.map(link => (
                 <Link
@@ -93,8 +93,8 @@ export function Navbar() {
                   onClick={() => setMobileOpen(false)}
                   className={`px-3 py-2 rounded-lg text-sm font-medium ${
                     location.pathname === link.to
-                      ? 'bg-primary/10 text-primary-light'
-                      : 'text-text-secondary hover:bg-surface-light'
+                      ? 'bg-primary-container text-on-primary-container'
+                      : 'text-on-surface-variant hover:bg-surface-container-high'
                   }`}
                 >
                   {link.label}
@@ -107,8 +107,8 @@ export function Navbar() {
               ) : isAuthenticated ? (
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <UserIcon size={16} className="text-text-muted" />
-                    <span className="text-sm text-text-secondary">{user?.username}</span>
+                    <UserIcon size={16} className="text-outline" />
+                    <span className="text-sm text-on-surface-variant">{user?.username}</span>
                   </div>
                   <button onClick={() => { logout(); setMobileOpen(false); }} className="text-sm text-error">
                     Logout

--- a/front/src/components/ui/Avatar.tsx
+++ b/front/src/components/ui/Avatar.tsx
@@ -29,7 +29,7 @@ export function Avatar({ src, name, size = 'md', className }: AvatarProps) {
   return (
     <div
       className={clsx(
-        'rounded-full bg-primary/20 text-primary flex items-center justify-center font-medium',
+        'rounded-full bg-primary-container text-primary flex items-center justify-center font-medium',
         sizeStyles[size],
         className
       )}

--- a/front/src/components/ui/Badge.tsx
+++ b/front/src/components/ui/Badge.tsx
@@ -9,8 +9,8 @@ interface BadgeProps {
 }
 
 const variantStyles: Record<BadgeVariant, string> = {
-  default: 'bg-surface-lighter text-text-secondary',
-  primary: 'bg-primary/20 text-primary-light',
+  default: 'bg-surface-container-highest text-on-surface-variant',
+  primary: 'bg-primary-container text-on-primary-container',
   success: 'bg-success/20 text-success',
   warning: 'bg-warning/20 text-warning',
   error: 'bg-error/20 text-error',

--- a/front/src/components/ui/Button.tsx
+++ b/front/src/components/ui/Button.tsx
@@ -11,9 +11,9 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantStyles: Record<ButtonVariant, string> = {
-  primary: 'bg-primary hover:bg-primary-dark text-white',
-  secondary: 'bg-surface-light hover:bg-surface-lighter text-text-primary border border-surface-lighter',
-  ghost: 'bg-transparent hover:bg-surface-light text-text-secondary',
+  primary: 'bg-primary hover:bg-primary/80 text-white',
+  secondary: 'bg-surface-container-high hover:bg-surface-container-highest text-on-surface border border-outline-variant',
+  ghost: 'bg-transparent hover:bg-surface-container-high text-on-surface-variant',
   danger: 'bg-error/10 hover:bg-error/20 text-error border border-error/30',
 };
 

--- a/front/src/components/ui/EmptyState.tsx
+++ b/front/src/components/ui/EmptyState.tsx
@@ -12,9 +12,9 @@ interface EmptyStateProps {
 export function EmptyState({ icon: Icon = InboxIcon, title, description, action }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
-      <Icon size={48} className="text-text-muted mb-4" />
-      <h3 className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
-      {description && <p className="text-text-secondary text-sm max-w-md mb-6">{description}</p>}
+      <Icon size={48} className="text-outline mb-4" />
+      <h3 className="text-lg font-semibold text-on-surface mb-2">{title}</h3>
+      {description && <p className="text-on-surface-variant text-sm max-w-md mb-6">{description}</p>}
       {action}
     </div>
   );

--- a/front/src/components/ui/Modal.tsx
+++ b/front/src/components/ui/Modal.tsx
@@ -39,16 +39,16 @@ export function Modal({ isOpen, onClose, title, children, className }: ModalProp
     >
       <div
         className={clsx(
-          'bg-surface rounded-xl shadow-2xl w-full max-w-md border border-surface-lighter animate-in fade-in zoom-in-95',
+          'bg-surface-container rounded-xl shadow-2xl w-full max-w-md border border-outline-variant animate-in fade-in zoom-in-95',
           className
         )}
       >
         {title && (
-          <div className="flex items-center justify-between px-6 py-4 border-b border-surface-lighter">
-            <h3 className="text-lg font-semibold text-text-primary">{title}</h3>
+          <div className="flex items-center justify-between px-6 py-4 border-b border-outline-variant">
+            <h3 className="text-lg font-semibold text-on-surface">{title}</h3>
             <button
               onClick={onClose}
-              className="p-1 rounded-lg hover:bg-surface-light text-text-muted hover:text-text-primary transition-colors"
+              className="p-1 rounded-lg hover:bg-surface-container-high text-outline hover:text-on-surface transition-colors"
             >
               <X size={20} />
             </button>


### PR DESCRIPTION
## Summary
- UI 컴포넌트 5개(Button, Badge, Modal, Avatar, EmptyState)와 레이아웃 컴포넌트 3개(Navbar, Footer, AuthLayout)의 Tailwind 색상 클래스를 MD3 토큰명으로 교체
- 주요 매핑: `surface-light` → `surface-container-high`, `text-text-primary` → `on-surface`, `accent` → `tertiary`, `primary-dark` → `primary/80`, `background` → `surface` 등
- CLAUDE.md 스타일링 섹션을 MD3 토큰 체계에 맞게 업데이트

## Test plan
- [x] `components/ui/` 내 기존 토큰 grep 검출 0건 확인
- [x] `components/layout/` 내 기존 토큰 grep 검출 0건 확인
- [x] `npm run build` 성공 확인 (TypeScript + Vite)
- [ ] 브라우저에서 전체 페이지 시각적 확인 (#6 병합 후)

> **Note:** 이 PR은 #6 (index.css MD3 토큰 교체)이 먼저 병합되어야 색상이 정상 적용됩니다.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)