### PR TITLE
feat(backend): Anime 서비스 + REST 컨트롤러 구현

### DIFF
--- a/back/src/main/kotlin/com/anirec/domain/anime/client/JikanClient.kt
+++ b/back/src/main/kotlin/com/anirec/domain/anime/client/JikanClient.kt
@@ -17,6 +17,7 @@ class JikanClient(private val jikanWebClient: WebClient) {
         status: String? = null,
         orderBy: String? = null,
         sort: String? = null,
+        genres: String? = null,
     ): JikanResponse =
         jikanWebClient.get()
             .uri { builder ->
@@ -28,6 +29,7 @@ class JikanClient(private val jikanWebClient: WebClient) {
                     .queryParamIfPresent("status", status)
                     .queryParamIfPresent("order_by", orderBy)
                     .queryParamIfPresent("sort", sort)
+                    .queryParamIfPresent("genres", genres)
                     .build()
             }
             .retrieve()

--- a/back/src/main/kotlin/com/anirec/domain/anime/controller/AnimeController.kt
+++ b/back/src/main/kotlin/com/anirec/domain/anime/controller/AnimeController.kt
@@ -1,0 +1,48 @@
+package com.anirec.domain.anime.controller
+
+import com.anirec.domain.anime.dto.JikanResponse
+import com.anirec.domain.anime.service.AnimeService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/anime")
+class AnimeController(private val animeService: AnimeService) {
+
+    @GetMapping
+    suspend fun search(
+        @RequestParam(required = false) q: String?,
+        @RequestParam(required = false) type: String?,
+        @RequestParam(required = false) genres: String?,
+        @RequestParam(required = false) orderBy: String?,
+        @RequestParam(required = false) sort: String?,
+        @RequestParam(required = false) page: Int?,
+        @RequestParam(required = false) limit: Int?,
+    ): JikanResponse =
+        animeService.search(query = q, page = page, limit = limit, type = type, genres = genres, orderBy = orderBy, sort = sort)
+
+    @GetMapping("/top")
+    suspend fun getTop(
+        @RequestParam(required = false) page: Int?,
+        @RequestParam(required = false) limit: Int?,
+    ): JikanResponse =
+        animeService.getTop(page = page, limit = limit)
+
+    @GetMapping("/season")
+    suspend fun getSeasonal(
+        @RequestParam year: Int,
+        @RequestParam season: String,
+        @RequestParam(required = false) page: Int?,
+        @RequestParam(required = false) limit: Int?,
+    ): JikanResponse =
+        animeService.getSeasonal(year = year, season = season, page = page, limit = limit)
+
+    @GetMapping("/season/now")
+    suspend fun getCurrentSeason(
+        @RequestParam(required = false) page: Int?,
+        @RequestParam(required = false) limit: Int?,
+    ): JikanResponse =
+        animeService.getCurrentSeason(page = page, limit = limit)
+}

--- a/back/src/main/kotlin/com/anirec/domain/anime/service/AnimeCacheService.kt
+++ b/back/src/main/kotlin/com/anirec/domain/anime/service/AnimeCacheService.kt
@@ -35,14 +35,16 @@ class AnimeCacheService(
         status: String? = null,
         orderBy: String? = null,
         sort: String? = null,
+        genres: String? = null,
     ): JikanResponse {
         val key = buildKey(
             "search",
             "q" to query, "page" to page, "limit" to limit,
             "type" to type, "status" to status, "orderBy" to orderBy, "sort" to sort,
+            "genres" to genres,
         )
         return getOrFetch(key, SEARCH_TTL) {
-            jikanClient.searchAnime(query, page, limit, type, status, orderBy, sort)
+            jikanClient.searchAnime(query, page, limit, type, status, orderBy, sort, genres)
         }
     }
 

--- a/back/src/main/kotlin/com/anirec/domain/anime/service/AnimeService.kt
+++ b/back/src/main/kotlin/com/anirec/domain/anime/service/AnimeService.kt
@@ -1,0 +1,48 @@
+package com.anirec.domain.anime.service
+
+import com.anirec.domain.anime.client.JikanClient
+import com.anirec.domain.anime.dto.JikanResponse
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class AnimeService(
+    private val jikanClient: JikanClient,
+    @Autowired(required = false) private val animeCacheService: AnimeCacheService?,
+) {
+
+    suspend fun search(
+        query: String? = null,
+        page: Int? = null,
+        limit: Int? = null,
+        type: String? = null,
+        genres: String? = null,
+        orderBy: String? = null,
+        sort: String? = null,
+    ): JikanResponse =
+        animeCacheService?.searchAnime(query, page, limit, type, orderBy = orderBy, sort = sort, genres = genres)
+            ?: jikanClient.searchAnime(query, page, limit, type, orderBy = orderBy, sort = sort, genres = genres)
+
+    suspend fun getTop(
+        page: Int? = null,
+        limit: Int? = null,
+    ): JikanResponse =
+        animeCacheService?.getTopAnime(page, limit)
+            ?: jikanClient.getTopAnime(page, limit)
+
+    suspend fun getSeasonal(
+        year: Int,
+        season: String,
+        page: Int? = null,
+        limit: Int? = null,
+    ): JikanResponse =
+        animeCacheService?.getSeasonalAnime(year, season, page, limit)
+            ?: jikanClient.getSeasonalAnime(year, season, page, limit)
+
+    suspend fun getCurrentSeason(
+        page: Int? = null,
+        limit: Int? = null,
+    ): JikanResponse =
+        animeCacheService?.getCurrentSeasonAnime(page, limit)
+            ?: jikanClient.getCurrentSeasonAnime(page, limit)
+}

--- a/back/src/main/kotlin/com/anirec/global/security/SecurityConfig.kt
+++ b/back/src/main/kotlin/com/anirec/global/security/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.anirec.global.security
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
@@ -30,6 +31,7 @@ class SecurityConfig {
             .formLogin { it.disable() }
             .authorizeExchange {
                 it.pathMatchers("/actuator/health").permitAll()
+                it.pathMatchers(HttpMethod.GET, "/api/anime", "/api/anime/**").permitAll()
                 it.pathMatchers("/api/**").authenticated()
                 it.anyExchange().permitAll()
             }

--- a/back/src/test/kotlin/com/anirec/domain/anime/service/AnimeServiceTest.kt
+++ b/back/src/test/kotlin/com/anirec/domain/anime/service/AnimeServiceTest.kt
@@ -1,0 +1,146 @@
+package com.anirec.domain.anime.service
+
+import com.anirec.domain.anime.client.JikanClient
+import com.anirec.domain.anime.dto.AnimeDto
+import com.anirec.domain.anime.dto.JikanResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class AnimeServiceTest {
+
+    private val jikanClient: JikanClient = mockk()
+    private val animeCacheService: AnimeCacheService = mockk()
+
+    private val sampleResponse = JikanResponse(
+        pagination = JikanResponse.Pagination(
+            lastVisiblePage = 1,
+            hasNextPage = false,
+            currentPage = 1,
+            items = JikanResponse.PaginationItems(count = 1, total = 1, perPage = 25),
+        ),
+        data = listOf(
+            AnimeDto(
+                malId = 1,
+                title = "Cowboy Bebop",
+                titleJapanese = "カウボーイビバップ",
+                synopsis = "A space bounty hunter crew.",
+                score = 8.78,
+                scoredBy = 900000,
+                rank = 28,
+                popularity = 39,
+                members = 1800000,
+                episodes = 26,
+                status = "Finished Airing",
+                type = "TV",
+                season = "spring",
+                year = 1998,
+                genres = listOf(AnimeDto.MalEntity(1, "Action")),
+                studios = listOf(AnimeDto.MalEntity(14, "Sunrise")),
+                images = AnimeDto.Images(AnimeDto.Images.JpgImage("url", "large_url")),
+                aired = AnimeDto.Aired("1998-04-03", "1999-04-24"),
+                url = "https://myanimelist.net/anime/1/Cowboy_Bebop",
+            )
+        ),
+    )
+
+    @Nested
+    inner class WithCacheService {
+        private val service = AnimeService(jikanClient, animeCacheService)
+
+        @Test
+        fun `search delegates to AnimeCacheService`() = runTest {
+            coEvery { animeCacheService.searchAnime(query = "bebop", page = 1) } returns sampleResponse
+
+            val result = service.search(query = "bebop", page = 1)
+
+            assertEquals(1, result.data.size)
+            assertEquals("Cowboy Bebop", result.data[0].title)
+            coVerify(exactly = 1) { animeCacheService.searchAnime(query = "bebop", page = 1) }
+            coVerify(exactly = 0) { jikanClient.searchAnime(any(), any(), any(), any(), any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `getTop delegates to AnimeCacheService`() = runTest {
+            coEvery { animeCacheService.getTopAnime(page = 1, limit = 25) } returns sampleResponse
+
+            val result = service.getTop(page = 1, limit = 25)
+
+            assertEquals(1, result.data.size)
+            coVerify(exactly = 1) { animeCacheService.getTopAnime(page = 1, limit = 25) }
+            coVerify(exactly = 0) { jikanClient.getTopAnime(any(), any(), any()) }
+        }
+
+        @Test
+        fun `getSeasonal delegates to AnimeCacheService`() = runTest {
+            coEvery { animeCacheService.getSeasonalAnime(2024, "winter", page = 1) } returns sampleResponse
+
+            val result = service.getSeasonal(year = 2024, season = "winter", page = 1)
+
+            assertEquals(1, result.data.size)
+            coVerify(exactly = 1) { animeCacheService.getSeasonalAnime(2024, "winter", page = 1) }
+            coVerify(exactly = 0) { jikanClient.getSeasonalAnime(any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `getCurrentSeason delegates to AnimeCacheService`() = runTest {
+            coEvery { animeCacheService.getCurrentSeasonAnime(page = 1) } returns sampleResponse
+
+            val result = service.getCurrentSeason(page = 1)
+
+            assertEquals(1, result.data.size)
+            coVerify(exactly = 1) { animeCacheService.getCurrentSeasonAnime(page = 1) }
+            coVerify(exactly = 0) { jikanClient.getCurrentSeasonAnime(any(), any()) }
+        }
+    }
+
+    @Nested
+    inner class WithoutCacheService {
+        private val service = AnimeService(jikanClient, null)
+
+        @Test
+        fun `search falls back to JikanClient`() = runTest {
+            coEvery { jikanClient.searchAnime(query = "bebop", page = 1) } returns sampleResponse
+
+            val result = service.search(query = "bebop", page = 1)
+
+            assertEquals(1, result.data.size)
+            assertEquals("Cowboy Bebop", result.data[0].title)
+            coVerify(exactly = 1) { jikanClient.searchAnime(query = "bebop", page = 1) }
+        }
+
+        @Test
+        fun `getTop falls back to JikanClient`() = runTest {
+            coEvery { jikanClient.getTopAnime(page = 1, limit = 25) } returns sampleResponse
+
+            val result = service.getTop(page = 1, limit = 25)
+
+            assertEquals(1, result.data.size)
+            coVerify(exactly = 1) { jikanClient.getTopAnime(page = 1, limit = 25) }
+        }
+
+        @Test
+        fun `getSeasonal falls back to JikanClient`() = runTest {
+            coEvery { jikanClient.getSeasonalAnime(2024, "winter", page = 1) } returns sampleResponse
+
+            val result = service.getSeasonal(year = 2024, season = "winter", page = 1)
+
+            assertEquals(1, result.data.size)
+            coVerify(exactly = 1) { jikanClient.getSeasonalAnime(2024, "winter", page = 1) }
+        }
+
+        @Test
+        fun `getCurrentSeason falls back to JikanClient`() = runTest {
+            coEvery { jikanClient.getCurrentSeasonAnime(page = 1) } returns sampleResponse
+
+            val result = service.getCurrentSeason(page = 1)
+
+            assertEquals(1, result.data.size)
+            coVerify(exactly = 1) { jikanClient.getCurrentSeasonAnime(page = 1) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `AnimeService` 생성: `AnimeCacheService`(Redis) 존재 시 캐시 위임, 없으면 `JikanClient` 직접 호출 fallback
- `AnimeController` 생성: 4개 REST 엔드포인트 (`GET /api/anime`, `/api/anime/top`, `/api/anime/season`, `/api/anime/season/now`)
- `JikanClient`, `AnimeCacheService`에 `genres` 파라미터 추가
- `SecurityConfig`에 `GET /api/anime/**` permitAll 규칙 추가
- `AnimeService` 단위 테스트 8개 작성 (캐시 위임 + fallback 시나리오)

## Test plan
- [x] `./gradlew build` 성공 (19 tests, 0 failures)
- [x] AnimeServiceTest — cache service 위임 및 fallback 로직 검증
- [x] 기존 테스트(JikanClientTest, AnimeCacheServiceIntegrationTest) 영향 없음

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)