### PR TITLE
feat(front): API 클라이언트 모듈 + 데이터 페칭 훅 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,11 @@ npm run preview   # 프로덕션 빌드 미리보기
 **`front/src/` 주요 디렉토리:**
 - `pages/` — 라우트 단위 페이지 컴포넌트
 - `components/` — 도메인별 구성: `ui/`, `layout/`, `anime/`, `auth/`, `filters/`, `home/`, `rating/`, `recommendation/`, `stats/`
-- `types/` — Jikan API 형태에 맞춘 TypeScript 인터페이스 (예: `Anime` 타입은 `mal_id`, `images.jpg.large_image_url` 사용)
-- `data/` — 목 데이터 파일 및 상수 (실제 API 호출 없음)
+- `types/` — TypeScript 인터페이스 (`anime.ts`: Jikan API 형태, `api.ts`: 페이지네이션/API 응답 제네릭 타입)
+- `api/` — 백엔드 API 클라이언트 (`client.ts`: 공통 fetch 래퍼 + `ApiError`, `animeApi.ts`: anime 엔드포인트 함수 4개)
+- `data/` — 목 데이터 파일 및 상수
 - `context/` — React 컨텍스트 (localStorage 기반 목 인증의 AuthContext)
-- `hooks/` — 커스텀 훅 (`useAuth`, `useLocalStorage`, `useFilterState`)
+- `hooks/` — 커스텀 훅 (`useAuth`, `useLocalStorage`, `useFilterState`, `useAnimeSearch`, `useTopAnime`, `useSeasonalAnime`)
 
 **라우팅 (`router.tsx`):**
 - `/` — 홈 (공개)
@@ -104,4 +105,4 @@ docker compose up -d    # MySQL 8 + Redis 7 로컬 인프라 기동
 
 ## 현재 상태
 
-프론트엔드는 목 데이터로 완전히 구성된 상태이며, 실제 API 연동은 아직 없습니다. 인증은 localStorage를 통한 가짜 구현입니다. 모든 애니메이션 데이터는 `data/mockAnime.ts`에서 제공됩니다. MD3 디자인 토큰이 `index.css`의 `@theme`에 정의 완료되었고 UI/레이아웃 공통 컴포넌트(Navbar, Footer, Button, Modal, Badge 등)는 MD3 토큰으로 마이그레이션됨. 나머지 컴포넌트(~30개 파일)는 아직 이전 토큰명을 참조하므로 후속 마이그레이션 필요. 백엔드는 인증 모듈(`domain/auth/`)과 Jikan API 클라이언트 + Redis 캐싱 레이어(`domain/anime/`)가 구현된 상태입니다. `domain/rating/`, `domain/recommendation/`은 아직 미구현입니다. 다음 주요 단계는 나머지 컴포넌트 MD3 토큰 마이그레이션, 애니메이션 REST API 컨트롤러 구현, 프론트엔드-백엔드 연동입니다.
+프론트엔드는 API 클라이언트 모듈(`api/client.ts`, `api/animeApi.ts`)과 데이터 페칭 훅(`useAnimeSearch`, `useTopAnime`, `useSeasonalAnime`)이 구현된 상태입니다. 단, 페이지 컴포넌트에서는 아직 목 데이터(`data/mockAnime.ts`)를 사용 중이며, 훅으로의 전환은 미완료입니다. 인증은 localStorage를 통한 가짜 구현입니다. 환경변수 `VITE_API_BASE_URL`(`.env.development`)로 백엔드 URL을 설정합니다. MD3 디자인 토큰이 `index.css`의 `@theme`에 정의 완료되었고 UI/레이아웃 공통 컴포넌트(Navbar, Footer, Button, Modal, Badge 등)는 MD3 토큰으로 마이그레이션됨. 나머지 컴포넌트(~30개 파일)는 아직 이전 토큰명을 참조하므로 후속 마이그레이션 필요. 백엔드는 인증 모듈(`domain/auth/`), Jikan API 클라이언트 + Redis 캐싱 레이어, 그리고 Anime REST API(`GET /api/anime`, `/api/anime/top`, `/api/anime/season`, `/api/anime/season/now`)가 구현된 상태입니다. `domain/rating/`, `domain/recommendation/`은 아직 미구현입니다. 다음 주요 단계는 나머지 컴포넌트 MD3 토큰 마이그레이션, 페이지 컴포넌트에서 목 데이터를 API 훅으로 교체하는 프론트엔드-백엔드 연동입니다.

--- a/front/.env.development
+++ b/front/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/front/src/api/animeApi.ts
+++ b/front/src/api/animeApi.ts
@@ -1,0 +1,46 @@
+import type { Anime } from '@/types/anime';
+import type { PaginatedResponse } from '@/types/api';
+import { apiClient } from './client';
+
+export interface SearchParams {
+  q?: string;
+  type?: string;
+  genres?: string;
+  orderBy?: string;
+  sort?: string;
+  page?: number;
+  limit?: number;
+}
+
+export function searchAnime(
+  params: SearchParams = {},
+  signal?: AbortSignal,
+): Promise<PaginatedResponse<Anime>> {
+  return apiClient.get('/api/anime', { ...params }, signal);
+}
+
+export function getTopAnime(
+  page?: number,
+  limit?: number,
+  signal?: AbortSignal,
+): Promise<PaginatedResponse<Anime>> {
+  return apiClient.get('/api/anime/top', { page, limit }, signal);
+}
+
+export function getSeasonalAnime(
+  year: number,
+  season: string,
+  page?: number,
+  limit?: number,
+  signal?: AbortSignal,
+): Promise<PaginatedResponse<Anime>> {
+  return apiClient.get('/api/anime/season', { year, season, page, limit }, signal);
+}
+
+export function getCurrentSeasonAnime(
+  page?: number,
+  limit?: number,
+  signal?: AbortSignal,
+): Promise<PaginatedResponse<Anime>> {
+  return apiClient.get('/api/anime/season/now', { page, limit }, signal);
+}

--- a/front/src/api/client.ts
+++ b/front/src/api/client.ts
@@ -1,0 +1,40 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+async function get<T>(
+  path: string,
+  params?: Record<string, string | number | undefined | null>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const url = new URL(path, BASE_URL);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value != null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: { 'Content-Type': 'application/json' },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new ApiError(response.status, `HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export const apiClient = { get };

--- a/front/src/hooks/useAnimeSearch.ts
+++ b/front/src/hooks/useAnimeSearch.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Anime } from '@/types/anime';
+import type { Pagination } from '@/types/api';
+import { searchAnime } from '@/api/animeApi';
+import type { SearchParams } from '@/api/animeApi';
+
+const DEBOUNCE_MS = 300;
+
+export function useAnimeSearch(params: SearchParams) {
+  const { q, type, genres, orderBy, sort, page, limit } = params;
+  const [data, setData] = useState<Anime[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setIsLoading(true);
+      setError(null);
+
+      searchAnime({ q, type, genres, orderBy, sort, page, limit }, controller.signal)
+        .then((res) => {
+          setData(res.data);
+          setPagination(res.pagination);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof DOMException && err.name === 'AbortError') return;
+          setError(err instanceof Error ? err : new Error(String(err)));
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setIsLoading(false);
+          }
+        });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [q, type, genres, orderBy, sort, page, limit]);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  return { data, pagination, isLoading, error };
+}

--- a/front/src/hooks/useSeasonalAnime.ts
+++ b/front/src/hooks/useSeasonalAnime.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Anime } from '@/types/anime';
+import type { Pagination } from '@/types/api';
+import { getSeasonalAnime, getCurrentSeasonAnime } from '@/api/animeApi';
+
+export function useSeasonalAnime(
+  year?: number,
+  season?: string,
+  page?: number,
+  limit?: number,
+) {
+  const [data, setData] = useState<Anime[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    const request =
+      year != null && season != null
+        ? getSeasonalAnime(year, season, page, limit, controller.signal)
+        : getCurrentSeasonAnime(page, limit, controller.signal);
+
+    request
+      .then((res) => {
+        setData(res.data);
+        setPagination(res.pagination);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+      setIsLoading(true);
+      setError(null);
+    };
+  }, [year, season, page, limit]);
+
+  return { data, pagination, isLoading, error };
+}

--- a/front/src/hooks/useTopAnime.ts
+++ b/front/src/hooks/useTopAnime.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Anime } from '@/types/anime';
+import type { Pagination } from '@/types/api';
+import { getTopAnime } from '@/api/animeApi';
+
+export function useTopAnime(page?: number, limit?: number) {
+  const [data, setData] = useState<Anime[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    getTopAnime(page, limit, controller.signal)
+      .then((res) => {
+        setData(res.data);
+        setPagination(res.pagination);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+      setIsLoading(true);
+      setError(null);
+    };
+  }, [page, limit]);
+
+  return { data, pagination, isLoading, error };
+}

--- a/front/src/types/api.ts
+++ b/front/src/types/api.ts
@@ -1,0 +1,17 @@
+export interface PaginationItems {
+  count: number;
+  total: number;
+  per_page: number;
+}
+
+export interface Pagination {
+  last_visible_page: number;
+  has_next_page: boolean;
+  current_page: number;
+  items: PaginationItems | null;
+}
+
+export interface PaginatedResponse<T> {
+  pagination: Pagination | null;
+  data: T[];
+}


### PR DESCRIPTION
## Summary
- 백엔드 REST API(`/api/anime/*`) 호출을 위한 공통 fetch 래퍼(`apiClient.get`) 및 `ApiError` 클래스 구현
- anime 엔드포인트 함수 4개(`searchAnime`, `getTopAnime`, `getSeasonalAnime`, `getCurrentSeasonAnime`) 및 페이지네이션 제네릭 타입(`PaginatedResponse<T>`) 추가
- 데이터 페칭 커스텀 훅 3개(`useAnimeSearch`, `useTopAnime`, `useSeasonalAnime`) 구현 — AbortController 기반 요청 취소, useAnimeSearch는 300ms 디바운스 포함
- 개발용 환경변수 파일(`.env.development`)에 `VITE_API_BASE_URL` 설정
- CLAUDE.md 현재 상태 업데이트

## 신규 파일
| 파일 | 설명 |
|---|---|
| `front/.env.development` | `VITE_API_BASE_URL=http://localhost:8080` |
| `front/src/types/api.ts` | `Pagination`, `PaginationItems`, `PaginatedResponse<T>` |
| `front/src/api/client.ts` | 공통 fetch 래퍼 + `ApiError` |
| `front/src/api/animeApi.ts` | anime 엔드포인트 함수 4개 |
| `front/src/hooks/useAnimeSearch.ts` | 검색 훅 (디바운스 300ms) |
| `front/src/hooks/useTopAnime.ts` | 탑 애니메이션 훅 |
| `front/src/hooks/useSeasonalAnime.ts` | 시즌 애니메이션 훅 (현재 시즌 자동 감지) |

## Test plan
- [x] `npm run build` 성공 (TypeScript 타입 체크 + Vite 빌드)
- [x] `npm run lint` 성공 (신규 파일에서 에러/워닝 0건)
- [ ] 백엔드 실행 상태에서 `npm run dev` → 브라우저 콘솔에서 API 함수 호출 시 데이터 수신 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)