### PR TITLE
refactor(front): anime/auth/filters 도메인 컴포넌트 MD3 테마 토큰 마이그레이션

### DIFF
--- a/front/src/components/anime/AnimeCard.tsx
+++ b/front/src/components/anime/AnimeCard.tsx
@@ -10,7 +10,7 @@ interface AnimeCardProps {
 
 export function AnimeCard({ anime, onRate }: AnimeCardProps) {
   return (
-    <div className="group relative rounded-xl overflow-hidden bg-surface shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/5">
+    <div className="group relative rounded-xl overflow-hidden bg-surface-container shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/5">
       <a href={anime.url} target="_blank" rel="noopener noreferrer" className="block">
         <div className="relative aspect-[225/320] overflow-hidden">
           <img
@@ -20,14 +20,14 @@ export function AnimeCard({ anime, onRate }: AnimeCardProps) {
             loading="lazy"
           />
           <div className="absolute top-2 right-2">
-            <Badge variant="warning" className="flex items-center gap-1 !bg-yellow-500/90 !text-black font-bold">
+            <Badge variant="warning" className="flex items-center gap-1 !bg-warning/90 !text-surface font-bold">
               <Star size={12} fill="currentColor" />
               {anime.score.toFixed(1)}
             </Badge>
           </div>
           <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300">
             <div className="absolute bottom-0 left-0 right-0 p-3 space-y-2">
-              <div className="text-xs text-gray-300 space-y-1">
+              <div className="text-xs text-on-surface-variant space-y-1">
                 {anime.studios.length > 0 && (
                   <p>Studio: {anime.studios.map(s => s.name).join(', ')}</p>
                 )}
@@ -39,7 +39,7 @@ export function AnimeCard({ anime, onRate }: AnimeCardProps) {
               {onRate && (
                 <button
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRate(anime); }}
-                  className="w-full py-1.5 rounded-lg bg-primary hover:bg-primary-dark text-white text-xs font-medium transition-colors flex items-center justify-center gap-1"
+                  className="w-full py-1.5 rounded-lg bg-primary hover:bg-primary/80 text-on-primary text-xs font-medium transition-colors flex items-center justify-center gap-1"
                 >
                   <Star size={12} /> Rate
                 </button>
@@ -49,10 +49,10 @@ export function AnimeCard({ anime, onRate }: AnimeCardProps) {
         </div>
       </a>
       <div className="p-3">
-        <h3 className="text-sm font-medium text-text-primary line-clamp-2 mb-2 leading-tight">
+        <h3 className="text-sm font-medium text-on-surface line-clamp-2 mb-2 leading-tight">
           {anime.title}
         </h3>
-        <div className="flex items-center gap-2 text-xs text-text-muted mb-2">
+        <div className="flex items-center gap-2 text-xs text-outline mb-2">
           <span className="flex items-center gap-1">
             <Play size={10} />
             {anime.type}

--- a/front/src/components/anime/AnimeListItem.tsx
+++ b/front/src/components/anime/AnimeListItem.tsx
@@ -14,10 +14,10 @@ export function AnimeListItem({ anime, rank }: AnimeListItemProps) {
       href={anime.url}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex items-center gap-4 p-3 rounded-xl bg-surface hover:bg-surface-light transition-colors group"
+      className="flex items-center gap-4 p-3 rounded-xl bg-surface-container hover:bg-surface-container-high transition-colors group"
     >
       {rank !== undefined && (
-        <span className="text-2xl font-bold text-text-muted w-8 text-center shrink-0">
+        <span className="text-2xl font-bold text-outline w-8 text-center shrink-0">
           {rank}
         </span>
       )}
@@ -28,12 +28,12 @@ export function AnimeListItem({ anime, rank }: AnimeListItemProps) {
         loading="lazy"
       />
       <div className="flex-1 min-w-0">
-        <h4 className="text-sm font-medium text-text-primary truncate group-hover:text-primary-light transition-colors">
+        <h4 className="text-sm font-medium text-on-surface truncate group-hover:text-primary transition-colors">
           {anime.title}
         </h4>
         <div className="flex items-center gap-2 mt-1">
-          <span className="text-xs text-text-muted">{anime.type}</span>
-          {anime.episodes && <span className="text-xs text-text-muted">{anime.episodes} eps</span>}
+          <span className="text-xs text-outline">{anime.type}</span>
+          {anime.episodes && <span className="text-xs text-outline">{anime.episodes} eps</span>}
           <div className="flex gap-1">
             {anime.genres.slice(0, 2).map(g => (
               <Badge key={g.mal_id} className="!text-[10px] !px-1.5 !py-0">{g.name}</Badge>
@@ -43,9 +43,9 @@ export function AnimeListItem({ anime, rank }: AnimeListItemProps) {
       </div>
       <div className="flex items-center gap-1 shrink-0">
         <Star size={14} className="text-warning fill-warning" />
-        <span className="text-sm font-semibold text-text-primary">{anime.score.toFixed(1)}</span>
+        <span className="text-sm font-semibold text-on-surface">{anime.score.toFixed(1)}</span>
       </div>
-      <ExternalLink size={14} className="text-text-muted opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+      <ExternalLink size={14} className="text-outline opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
     </a>
   );
 }

--- a/front/src/components/auth/LoginForm.tsx
+++ b/front/src/components/auth/LoginForm.tsx
@@ -29,42 +29,42 @@ export function LoginForm() {
   };
 
   return (
-    <div className="bg-surface rounded-xl p-8 border border-surface-lighter shadow-2xl">
-      <h2 className="text-2xl font-bold text-text-primary mb-2">Welcome back</h2>
-      <p className="text-text-secondary text-sm mb-6">Sign in to your AniRec account</p>
+    <div className="bg-surface-container rounded-xl p-8 border border-outline-variant shadow-2xl">
+      <h2 className="text-2xl font-bold text-on-surface mb-2">Welcome back</h2>
+      <p className="text-on-surface-variant text-sm mb-6">Sign in to your AniRec account</p>
 
       {formError && (
-        <div className="mb-4 p-3 rounded-lg bg-error/10 border border-error/30 text-error text-sm">
+        <div className="mb-4 p-3 rounded-lg bg-error-container border border-error-container text-on-error-container text-sm">
           {formError}
         </div>
       )}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm text-text-secondary mb-1.5">Email</label>
+          <label className="block text-sm text-on-surface-variant mb-1.5">Email</label>
           <div className="relative">
-            <Mail size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+            <Mail size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-outline" />
             <input
               type="email"
               value={email}
               onChange={e => setEmail(e.target.value)}
               placeholder="you@example.com"
               required
-              className="w-full pl-10 pr-4 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              className="w-full pl-10 pr-4 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface placeholder-outline text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
             />
           </div>
         </div>
         <div>
-          <label className="block text-sm text-text-secondary mb-1.5">Password</label>
+          <label className="block text-sm text-on-surface-variant mb-1.5">Password</label>
           <div className="relative">
-            <Lock size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+            <Lock size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-outline" />
             <input
               type="password"
               value={password}
               onChange={e => setPassword(e.target.value)}
               placeholder="••••••••"
               required
-              className="w-full pl-10 pr-4 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              className="w-full pl-10 pr-4 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface placeholder-outline text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
             />
           </div>
         </div>
@@ -73,9 +73,9 @@ export function LoginForm() {
         </Button>
       </form>
 
-      <p className="text-center text-sm text-text-secondary mt-6">
+      <p className="text-center text-sm text-on-surface-variant mt-6">
         Don't have an account?{' '}
-        <Link to="/signup" className="text-primary-light hover:text-primary transition-colors">Sign up</Link>
+        <Link to="/signup" className="text-primary hover:text-primary transition-colors">Sign up</Link>
       </p>
     </div>
   );

--- a/front/src/components/auth/SignupForm.tsx
+++ b/front/src/components/auth/SignupForm.tsx
@@ -28,56 +28,56 @@ export function SignupForm() {
   };
 
   return (
-    <div className="bg-surface rounded-xl p-8 border border-surface-lighter shadow-2xl">
-      <h2 className="text-2xl font-bold text-text-primary mb-2">Create account</h2>
-      <p className="text-text-secondary text-sm mb-6">Join AniRec and discover great anime</p>
+    <div className="bg-surface-container rounded-xl p-8 border border-outline-variant shadow-2xl">
+      <h2 className="text-2xl font-bold text-on-surface mb-2">Create account</h2>
+      <p className="text-on-surface-variant text-sm mb-6">Join AniRec and discover great anime</p>
 
       {formError && (
-        <div className="mb-4 p-3 rounded-lg bg-error/10 border border-error/30 text-error text-sm">
+        <div className="mb-4 p-3 rounded-lg bg-error-container border border-error-container text-on-error-container text-sm">
           {formError}
         </div>
       )}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm text-text-secondary mb-1.5">Username</label>
+          <label className="block text-sm text-on-surface-variant mb-1.5">Username</label>
           <div className="relative">
-            <User size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+            <User size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-outline" />
             <input
               type="text"
               value={username}
               onChange={e => setUsername(e.target.value)}
               placeholder="animefan42"
               required
-              className="w-full pl-10 pr-4 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              className="w-full pl-10 pr-4 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface placeholder-outline text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
             />
           </div>
         </div>
         <div>
-          <label className="block text-sm text-text-secondary mb-1.5">Email</label>
+          <label className="block text-sm text-on-surface-variant mb-1.5">Email</label>
           <div className="relative">
-            <Mail size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+            <Mail size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-outline" />
             <input
               type="email"
               value={email}
               onChange={e => setEmail(e.target.value)}
               placeholder="you@example.com"
               required
-              className="w-full pl-10 pr-4 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              className="w-full pl-10 pr-4 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface placeholder-outline text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
             />
           </div>
         </div>
         <div>
-          <label className="block text-sm text-text-secondary mb-1.5">Password</label>
+          <label className="block text-sm text-on-surface-variant mb-1.5">Password</label>
           <div className="relative">
-            <Lock size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+            <Lock size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-outline" />
             <input
               type="password"
               value={password}
               onChange={e => setPassword(e.target.value)}
               placeholder="••••••••"
               required
-              className="w-full pl-10 pr-4 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              className="w-full pl-10 pr-4 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface placeholder-outline text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
             />
           </div>
         </div>
@@ -86,9 +86,9 @@ export function SignupForm() {
         </Button>
       </form>
 
-      <p className="text-center text-sm text-text-secondary mt-6">
+      <p className="text-center text-sm text-on-surface-variant mt-6">
         Already have an account?{' '}
-        <Link to="/login" className="text-primary-light hover:text-primary transition-colors">Sign in</Link>
+        <Link to="/login" className="text-primary hover:text-primary transition-colors">Sign in</Link>
       </p>
     </div>
   );

--- a/front/src/components/filters/FilterBar.tsx
+++ b/front/src/components/filters/FilterBar.tsx
@@ -55,11 +55,11 @@ export function FilterBar({ filters, onFilterChange, onReset, resultCount }: Fil
           options={yearOptions}
         />
         {hasActiveFilters && (
-          <Button variant="ghost" size="sm" onClick={onReset} className="text-text-muted">
+          <Button variant="ghost" size="sm" onClick={onReset} className="text-outline">
             <RotateCcw size={14} /> Reset
           </Button>
         )}
-        <span className="text-sm text-text-muted ml-auto">{resultCount} results</span>
+        <span className="text-sm text-outline ml-auto">{resultCount} results</span>
       </div>
     </div>
   );

--- a/front/src/components/filters/FilterDropdown.tsx
+++ b/front/src/components/filters/FilterDropdown.tsx
@@ -10,7 +10,7 @@ export function FilterDropdown({ label, value, onChange, options }: FilterDropdo
     <select
       value={value}
       onChange={e => onChange(e.target.value)}
-      className="px-3 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none cursor-pointer"
+      className="px-3 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none cursor-pointer"
       aria-label={label}
     >
       <option value="">{label}</option>

--- a/front/src/components/filters/SearchInput.tsx
+++ b/front/src/components/filters/SearchInput.tsx
@@ -9,18 +9,18 @@ interface SearchInputProps {
 export function SearchInput({ value, onChange, placeholder = 'Search anime...' }: SearchInputProps) {
   return (
     <div className="relative">
-      <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+      <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-outline" />
       <input
         type="text"
         value={value}
         onChange={e => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full pl-10 pr-10 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary placeholder-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+        className="w-full pl-10 pr-10 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface placeholder-outline text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
       />
       {value && (
         <button
           onClick={() => onChange('')}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-outline hover:text-on-surface transition-colors"
         >
           <X size={16} />
         </button>

--- a/front/src/components/filters/SortSelector.tsx
+++ b/front/src/components/filters/SortSelector.tsx
@@ -9,11 +9,11 @@ interface SortSelectorProps {
 export function SortSelector({ value, onChange }: SortSelectorProps) {
   return (
     <div className="relative flex items-center">
-      <ArrowUpDown size={14} className="absolute left-3 text-text-muted pointer-events-none" />
+      <ArrowUpDown size={14} className="absolute left-3 text-outline pointer-events-none" />
       <select
         value={value}
         onChange={e => onChange(e.target.value)}
-        className="pl-8 pr-3 py-2.5 bg-surface-light border border-surface-lighter rounded-lg text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none cursor-pointer"
+        className="pl-8 pr-3 py-2.5 bg-surface-container-high border border-outline-variant rounded-lg text-on-surface text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none cursor-pointer"
       >
         {SORT_OPTIONS.map(opt => (
           <option key={opt.value} value={opt.value}>{opt.label}</option>


### PR DESCRIPTION
## Summary

- anime(`AnimeCard`, `AnimeListItem`), auth(`LoginForm`, `SignupForm`), filters(`SearchInput`, `FilterDropdown`, `FilterBar`, `SortSelector`) 8개 컴포넌트의 기존 커스텀 색상 토큰을 MD3 표준 토큰으로 교체
- 주요 매핑: `bg-surface` → `bg-surface-container`, `bg-surface-light` → `bg-surface-container-high`, `text-text-primary` → `text-on-surface`, `text-text-secondary` → `text-on-surface-variant`, `text-text-muted` → `text-outline`, `border-surface-lighter` → `border-outline-variant`, `text-primary-light` → `text-primary`
- 에러 박스를 `bg-error/10 text-error` → `bg-error-container text-on-error-container`로 MD3 error container 패턴 적용
- 점수 뱃지를 `!bg-yellow-500/90 !text-black` → `!bg-warning/90 !text-surface`로 시맨틱 토큰 적용

## Test plan

- [x] `components/anime/`, `components/auth/`, `components/filters/` 내 기존 토큰명 grep 검출 0건 확인
- [x] `npm run build` 성공 (TypeScript 에러 없음)
- [ ] 브라우저에서 다크 테마 시각 확인: 카드/리스트/폼/필터 영역 색상 정상 렌더링

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)