### PR TITLE
refactor(front): home, rating, recommendation 도메인 MD3 테마 토큰 마이그레이션

### DIFF
--- a/front/src/components/home/HeroSection.tsx
+++ b/front/src/components/home/HeroSection.tsx
@@ -8,17 +8,17 @@ export function HeroSection() {
 
   return (
     <section className="relative overflow-hidden py-20 sm:py-28">
-      <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-background to-accent/5" />
+      <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-surface to-tertiary/5" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--color-primary)_0%,transparent_50%)] opacity-10" />
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6">
-          <span className="bg-gradient-to-r from-primary via-accent to-primary-light bg-clip-text text-transparent">
+          <span className="bg-gradient-to-r from-primary via-tertiary to-primary-container bg-clip-text text-transparent">
             Discover Your Next
           </span>
           <br />
-          <span className="text-text-primary">Favorite Anime</span>
+          <span className="text-on-surface">Favorite Anime</span>
         </h1>
-        <p className="text-lg sm:text-xl text-text-secondary max-w-2xl mx-auto mb-10">
+        <p className="text-lg sm:text-xl text-on-surface-variant max-w-2xl mx-auto mb-10">
           Get personalized anime recommendations based on your taste.
           Rate, track, and explore thousands of titles.
         </p>

--- a/front/src/components/home/SeasonalSection.tsx
+++ b/front/src/components/home/SeasonalSection.tsx
@@ -12,11 +12,11 @@ export function SeasonalSection({ anime, onRate }: SeasonalSectionProps) {
   const currentYear = new Date().getFullYear();
 
   return (
-    <section className="py-10 bg-surface/30">
+    <section className="py-10 bg-surface-container/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-2 mb-6">
           <Calendar size={24} className="text-info" />
-          <h2 className="text-2xl font-bold text-text-primary">{currentSeason} {currentYear} Anime</h2>
+          <h2 className="text-2xl font-bold text-on-surface">{currentSeason} {currentYear} Anime</h2>
         </div>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
           {anime.slice(0, 6).map(a => (

--- a/front/src/components/home/TopAnimeList.tsx
+++ b/front/src/components/home/TopAnimeList.tsx
@@ -12,7 +12,7 @@ export function TopAnimeList({ anime }: TopAnimeListProps) {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-2 mb-6">
           <Trophy size={24} className="text-warning" />
-          <h2 className="text-2xl font-bold text-text-primary">Top Anime</h2>
+          <h2 className="text-2xl font-bold text-on-surface">Top Anime</h2>
         </div>
         <div className="space-y-2 max-w-3xl">
           {anime.slice(0, 10).map((a, i) => (

--- a/front/src/components/home/TrendingSection.tsx
+++ b/front/src/components/home/TrendingSection.tsx
@@ -13,7 +13,7 @@ export function TrendingSection({ anime, onRate }: TrendingSectionProps) {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-2 mb-6">
           <TrendingUp size={24} className="text-error" />
-          <h2 className="text-2xl font-bold text-text-primary">Trending Now</h2>
+          <h2 className="text-2xl font-bold text-on-surface">Trending Now</h2>
         </div>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
           {anime.slice(0, 6).map(a => (

--- a/front/src/components/rating/RatingInput.tsx
+++ b/front/src/components/rating/RatingInput.tsx
@@ -28,12 +28,12 @@ export function RatingInput({ value, onChange, max = 10 }: RatingInputProps) {
               'transition-colors',
               (hover || value) >= star
                 ? 'text-warning fill-warning'
-                : 'text-surface-lighter'
+                : 'text-surface-container-highest'
             )}
           />
         </button>
       ))}
-      <span className="ml-2 text-sm font-medium text-text-secondary">
+      <span className="ml-2 text-sm font-medium text-on-surface-variant">
         {hover || value || 0}/10
       </span>
     </div>

--- a/front/src/components/rating/RatingModal.tsx
+++ b/front/src/components/rating/RatingModal.tsx
@@ -37,18 +37,18 @@ export function RatingModal({ anime, isOpen, onClose, onSubmit }: RatingModalPro
             className="w-16 h-22 rounded-lg object-cover shrink-0"
           />
           <div>
-            <h4 className="font-medium text-text-primary">{anime.title}</h4>
-            <p className="text-sm text-text-muted mt-1">{anime.type} · {anime.episodes ?? '?'} episodes</p>
+            <h4 className="font-medium text-on-surface">{anime.title}</h4>
+            <p className="text-sm text-outline mt-1">{anime.type} · {anime.episodes ?? '?'} episodes</p>
           </div>
         </div>
 
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <span className="text-sm text-text-secondary">Your Rating</span>
+            <span className="text-sm text-on-surface-variant">Your Rating</span>
             <button
               type="button"
               onClick={() => setUseSlider(!useSlider)}
-              className="text-xs text-primary-light hover:text-primary transition-colors"
+              className="text-xs text-primary-container hover:text-primary transition-colors"
             >
               {useSlider ? 'Use stars' : 'Use slider'}
             </button>

--- a/front/src/components/rating/RatingSlider.tsx
+++ b/front/src/components/rating/RatingSlider.tsx
@@ -7,7 +7,7 @@ export function RatingSlider({ value, onChange }: RatingSliderProps) {
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <span className="text-sm text-text-secondary">Rating</span>
+        <span className="text-sm text-on-surface-variant">Rating</span>
         <span className="text-lg font-bold text-primary">{value}</span>
       </div>
       <input
@@ -17,9 +17,9 @@ export function RatingSlider({ value, onChange }: RatingSliderProps) {
         step={1}
         value={value}
         onChange={e => onChange(Number(e.target.value))}
-        className="w-full h-2 rounded-full appearance-none cursor-pointer bg-surface-lighter accent-primary"
+        className="w-full h-2 rounded-full appearance-none cursor-pointer bg-surface-container-highest accent-primary"
       />
-      <div className="flex justify-between text-xs text-text-muted">
+      <div className="flex justify-between text-xs text-outline">
         <span>1</span>
         <span>5</span>
         <span>10</span>

--- a/front/src/components/rating/WatchStatusSelector.tsx
+++ b/front/src/components/rating/WatchStatusSelector.tsx
@@ -10,7 +10,7 @@ interface WatchStatusSelectorProps {
 const statuses: { value: WatchStatus; label: string; icon: typeof Eye; color: string }[] = [
   { value: 'Watching', label: 'Watching', icon: Eye, color: 'text-info' },
   { value: 'Completed', label: 'Completed', icon: CheckCircle, color: 'text-success' },
-  { value: 'Plan to Watch', label: 'Plan to Watch', icon: Clock, color: 'text-accent' },
+  { value: 'Plan to Watch', label: 'Plan to Watch', icon: Clock, color: 'text-tertiary' },
   { value: 'Dropped', label: 'Dropped', icon: XCircle, color: 'text-error' },
   { value: 'On Hold', label: 'On Hold', icon: Pause, color: 'text-warning' },
 ];
@@ -18,7 +18,7 @@ const statuses: { value: WatchStatus; label: string; icon: typeof Eye; color: st
 export function WatchStatusSelector({ value, onChange }: WatchStatusSelectorProps) {
   return (
     <div className="space-y-2">
-      <span className="text-sm text-text-secondary">Watch Status</span>
+      <span className="text-sm text-on-surface-variant">Watch Status</span>
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
         {statuses.map(status => {
           const Icon = status.icon;
@@ -30,11 +30,11 @@ export function WatchStatusSelector({ value, onChange }: WatchStatusSelectorProp
               className={clsx(
                 'flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-all',
                 value === status.value
-                  ? 'border-primary bg-primary/10 text-primary-light'
-                  : 'border-surface-lighter bg-surface-light text-text-secondary hover:border-surface-lighter hover:bg-surface-lighter'
+                  ? 'border-primary bg-primary-container text-on-primary-container'
+                  : 'border-outline-variant bg-surface-container-high text-on-surface-variant hover:border-outline-variant hover:bg-surface-container-highest'
               )}
             >
-              <Icon size={14} className={value === status.value ? 'text-primary-light' : status.color} />
+              <Icon size={14} className={value === status.value ? 'text-on-primary-container' : status.color} />
               {status.label}
             </button>
           );

--- a/front/src/components/recommendation/FeedbackButtons.tsx
+++ b/front/src/components/recommendation/FeedbackButtons.tsx
@@ -15,7 +15,7 @@ export function FeedbackButtons({ feedback, onFeedback }: FeedbackButtonsProps) 
           'p-2 rounded-lg transition-all',
           feedback === 'like'
             ? 'bg-success/20 text-success'
-            : 'text-text-muted hover:bg-surface-lighter hover:text-success'
+            : 'text-outline hover:bg-surface-container-highest hover:text-success'
         )}
         title="Good recommendation"
       >
@@ -27,7 +27,7 @@ export function FeedbackButtons({ feedback, onFeedback }: FeedbackButtonsProps) 
           'p-2 rounded-lg transition-all',
           feedback === 'dislike'
             ? 'bg-error/20 text-error'
-            : 'text-text-muted hover:bg-surface-lighter hover:text-error'
+            : 'text-outline hover:bg-surface-container-highest hover:text-error'
         )}
         title="Not for me"
       >

--- a/front/src/components/recommendation/RecommendationCard.tsx
+++ b/front/src/components/recommendation/RecommendationCard.tsx
@@ -14,7 +14,7 @@ interface RecommendationCardProps {
 
 export function RecommendationCard({ recommendation, anime, onFeedback, onRate }: RecommendationCardProps) {
   return (
-    <div className="bg-surface rounded-xl border border-surface-lighter overflow-hidden hover:border-primary/30 transition-colors">
+    <div className="bg-surface-container rounded-xl border border-outline-variant overflow-hidden hover:border-primary/30 transition-colors">
       <div className="flex">
         <a href={anime.url} target="_blank" rel="noopener noreferrer" className="shrink-0">
           <img
@@ -28,7 +28,7 @@ export function RecommendationCard({ recommendation, anime, onFeedback, onRate }
           <div className="flex items-start justify-between gap-2">
             <div>
               <a href={anime.url} target="_blank" rel="noopener noreferrer" className="group">
-                <h3 className="font-medium text-text-primary group-hover:text-primary-light transition-colors flex items-center gap-1">
+                <h3 className="font-medium text-on-surface group-hover:text-primary-container transition-colors flex items-center gap-1">
                   {anime.title}
                   <ExternalLink size={12} className="opacity-0 group-hover:opacity-100" />
                 </h3>
@@ -36,9 +36,9 @@ export function RecommendationCard({ recommendation, anime, onFeedback, onRate }
               <div className="flex items-center gap-2 mt-1">
                 <div className="flex items-center gap-1">
                   <Star size={12} className="text-warning fill-warning" />
-                  <span className="text-xs text-text-secondary">{anime.score.toFixed(1)}</span>
+                  <span className="text-xs text-on-surface-variant">{anime.score.toFixed(1)}</span>
                 </div>
-                <span className="text-xs text-text-muted">{anime.type} · {anime.episodes ?? '?'} eps</span>
+                <span className="text-xs text-outline">{anime.type} · {anime.episodes ?? '?'} eps</span>
               </div>
             </div>
             <Badge variant="primary" className="shrink-0">
@@ -47,7 +47,7 @@ export function RecommendationCard({ recommendation, anime, onFeedback, onRate }
             </Badge>
           </div>
 
-          <p className="text-sm text-text-secondary">{recommendation.reason}</p>
+          <p className="text-sm text-on-surface-variant">{recommendation.reason}</p>
 
           <div className="flex flex-wrap gap-1">
             {anime.genres.slice(0, 3).map(g => (
@@ -58,7 +58,7 @@ export function RecommendationCard({ recommendation, anime, onFeedback, onRate }
           <div className="flex items-center justify-between pt-1">
             <button
               onClick={() => onRate(anime)}
-              className="text-xs text-primary-light hover:text-primary transition-colors font-medium"
+              className="text-xs text-primary-container hover:text-primary transition-colors font-medium"
             >
               Rate this anime
             </button>

--- a/front/src/components/recommendation/RecommendationSection.tsx
+++ b/front/src/components/recommendation/RecommendationSection.tsx
@@ -15,23 +15,23 @@ interface RecommendationSectionProps {
 export function RecommendationSection({ recommendations, animeMap, tasteGroup, onFeedback, onRate }: RecommendationSectionProps) {
   return (
     <div className="space-y-8">
-      <div className="bg-surface rounded-xl border border-surface-lighter p-6">
+      <div className="bg-surface-container rounded-xl border border-outline-variant p-6">
         <div className="flex items-center gap-2 mb-3">
-          <Sparkles size={20} className="text-accent" />
-          <h3 className="font-semibold text-text-primary">Your Taste Group</h3>
+          <Sparkles size={20} className="text-tertiary" />
+          <h3 className="font-semibold text-on-surface">Your Taste Group</h3>
         </div>
-        <p className="text-lg font-medium text-primary-light mb-2">{tasteGroup.name}</p>
-        <p className="text-sm text-text-secondary mb-4">{tasteGroup.description}</p>
+        <p className="text-lg font-medium text-primary-container mb-2">{tasteGroup.name}</p>
+        <p className="text-sm text-on-surface-variant mb-4">{tasteGroup.description}</p>
         <div className="flex flex-wrap gap-2">
           {tasteGroup.topGenres.map(genre => (
             <Badge key={genre} variant="primary">{genre}</Badge>
           ))}
         </div>
-        <p className="text-xs text-text-muted mt-3">{tasteGroup.memberCount.toLocaleString()} members in this group</p>
+        <p className="text-xs text-outline mt-3">{tasteGroup.memberCount.toLocaleString()} members in this group</p>
       </div>
 
       <div className="space-y-4">
-        <h3 className="text-xl font-bold text-text-primary flex items-center gap-2">
+        <h3 className="text-xl font-bold text-on-surface flex items-center gap-2">
           <Sparkles size={20} className="text-primary" />
           Recommended for You
         </h3>


### PR DESCRIPTION
## Summary
- `components/home/` 4개 파일(HeroSection, SeasonalSection, TopAnimeList, TrendingSection)의 색상 토큰을 MD3로 교체
- `components/rating/` 4개 파일(RatingModal, RatingInput, RatingSlider, WatchStatusSelector)의 색상 토큰을 MD3로 교체
- `components/recommendation/` 3개 파일(RecommendationCard, RecommendationSection, FeedbackButtons)의 색상 토큰을 MD3로 교체

### 주요 토큰 매핑
| 기존 | MD3 |
|---|---|
| `text-text-primary` | `text-on-surface` |
| `text-text-secondary` | `text-on-surface-variant` |
| `text-text-muted` | `text-outline` |
| `bg-surface-lighter` / `border-surface-lighter` | `bg-surface-container-highest` / `border-outline-variant` |
| `bg-surface-light` | `bg-surface-container-high` |
| `bg-surface` (카드/컨테이너) | `bg-surface-container` |
| `text-primary-light` | `text-primary-container` |
| `text-accent` / `via-accent` | `text-tertiary` / `via-tertiary` |
| `via-background` | `via-surface` |

Closes #9

## Test plan
- [x] `home/`, `rating/`, `recommendation/` 내 기존 토큰 grep 검출 0건 확인
- [x] `npm run build` 성공 (TypeScript 오류 없음)
- [ ] 브라우저에서 home, rating modal, recommendation 페이지 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)