### PR TITLE
feat(front): HomePage 실제 API 연동

### DIFF
--- a/front/src/components/home/SeasonalSection.tsx
+++ b/front/src/components/home/SeasonalSection.tsx
@@ -1,13 +1,16 @@
-import { Calendar } from 'lucide-react';
+import { Calendar, AlertTriangle } from 'lucide-react';
 import { AnimeCard } from '@/components/anime/AnimeCard';
+import { Spinner } from '@/components/ui/Spinner';
 import type { Anime } from '@/types/anime';
 
 interface SeasonalSectionProps {
   anime: Anime[];
   onRate?: (anime: Anime) => void;
+  isLoading?: boolean;
+  error?: Error | null;
 }
 
-export function SeasonalSection({ anime, onRate }: SeasonalSectionProps) {
+export function SeasonalSection({ anime, onRate, isLoading, error }: SeasonalSectionProps) {
   const currentSeason = (['Winter', 'Spring', 'Summer', 'Fall'] as const)[Math.floor(new Date().getMonth() / 3)];
   const currentYear = new Date().getFullYear();
 
@@ -18,11 +21,22 @@ export function SeasonalSection({ anime, onRate }: SeasonalSectionProps) {
           <Calendar size={24} className="text-info" />
           <h2 className="text-2xl font-bold text-text-primary">{currentSeason} {currentYear} Anime</h2>
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-          {anime.slice(0, 6).map(a => (
-            <AnimeCard key={a.mal_id} anime={a} onRate={onRate} />
-          ))}
-        </div>
+        {isLoading ? (
+          <div className="py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-2 py-12 justify-center text-error">
+            <AlertTriangle size={20} />
+            <p>Failed to load seasonal anime.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+            {anime.slice(0, 6).map(a => (
+              <AnimeCard key={a.mal_id} anime={a} onRate={onRate} />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/front/src/components/home/TopAnimeList.tsx
+++ b/front/src/components/home/TopAnimeList.tsx
@@ -1,12 +1,15 @@
-import { Trophy } from 'lucide-react';
+import { Trophy, AlertTriangle } from 'lucide-react';
 import { AnimeListItem } from '@/components/anime/AnimeListItem';
+import { Spinner } from '@/components/ui/Spinner';
 import type { Anime } from '@/types/anime';
 
 interface TopAnimeListProps {
   anime: Anime[];
+  isLoading?: boolean;
+  error?: Error | null;
 }
 
-export function TopAnimeList({ anime }: TopAnimeListProps) {
+export function TopAnimeList({ anime, isLoading, error }: TopAnimeListProps) {
   return (
     <section className="py-10">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -14,11 +17,22 @@ export function TopAnimeList({ anime }: TopAnimeListProps) {
           <Trophy size={24} className="text-warning" />
           <h2 className="text-2xl font-bold text-text-primary">Top Anime</h2>
         </div>
-        <div className="space-y-2 max-w-3xl">
-          {anime.slice(0, 10).map((a, i) => (
-            <AnimeListItem key={a.mal_id} anime={a} rank={i + 1} />
-          ))}
-        </div>
+        {isLoading ? (
+          <div className="py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-2 py-12 justify-center text-error">
+            <AlertTriangle size={20} />
+            <p>Failed to load top anime.</p>
+          </div>
+        ) : (
+          <div className="space-y-2 max-w-3xl">
+            {anime.slice(0, 10).map((a, i) => (
+              <AnimeListItem key={a.mal_id} anime={a} rank={i + 1} />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/front/src/components/home/TrendingSection.tsx
+++ b/front/src/components/home/TrendingSection.tsx
@@ -1,13 +1,16 @@
-import { TrendingUp } from 'lucide-react';
+import { TrendingUp, AlertTriangle } from 'lucide-react';
 import { AnimeCard } from '@/components/anime/AnimeCard';
+import { Spinner } from '@/components/ui/Spinner';
 import type { Anime } from '@/types/anime';
 
 interface TrendingSectionProps {
   anime: Anime[];
   onRate?: (anime: Anime) => void;
+  isLoading?: boolean;
+  error?: Error | null;
 }
 
-export function TrendingSection({ anime, onRate }: TrendingSectionProps) {
+export function TrendingSection({ anime, onRate, isLoading, error }: TrendingSectionProps) {
   return (
     <section className="py-10">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -15,11 +18,22 @@ export function TrendingSection({ anime, onRate }: TrendingSectionProps) {
           <TrendingUp size={24} className="text-error" />
           <h2 className="text-2xl font-bold text-text-primary">Trending Now</h2>
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-          {anime.slice(0, 6).map(a => (
-            <AnimeCard key={a.mal_id} anime={a} onRate={onRate} />
-          ))}
-        </div>
+        {isLoading ? (
+          <div className="py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-2 py-12 justify-center text-error">
+            <AlertTriangle size={20} />
+            <p>Failed to load trending anime.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+            {anime.slice(0, 6).map(a => (
+              <AnimeCard key={a.mal_id} anime={a} onRate={onRate} />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- HomePage의 Trending/Seasonal/Top 3개 섹션에서 `mockAnime` 목 데이터를 제거하고, 기존 구현된 `useSeasonalAnime`/`useTopAnime` API 훅으로 교체
- 각 섹션 컴포넌트(TrendingSection, SeasonalSection, TopAnimeList)에 개별 `isLoading`/`error` 상태를 추가하여 한 섹션의 API 실패가 다른 섹션에 영향을 주지 않도록 격리
- RecommendationSection은 아직 추천 API 미구현으로 `mockAnime` import 유지

## Test plan
- [ ] `npm run build` — TypeScript 컴파일 + Vite 빌드 성공 확인
- [ ] 홈페이지 접속 시 3개 섹션에 실제 MAL 데이터 표시 확인
- [ ] 브라우저 네트워크 탭에서 3개 API 호출 확인 (`/api/anime/top`, `/api/anime/season/now`, `/api/anime/season`)
- [ ] 각 섹션 로딩 시 스피너 표시 후 데이터로 전환 확인
- [ ] 한 섹션 API 실패 시 해당 섹션만 에러 표시, 나머지 정상 동작 확인

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)