### PR TITLE
refactor(front): 차트 컴포넌트 인라인 색상 MD3 토큰 마이그레이션

### DIFF
--- a/front/src/components/stats/GenreBarChart.tsx
+++ b/front/src/components/stats/GenreBarChart.tsx
@@ -1,27 +1,26 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import type { GenreStat } from '@/types/stats';
+import { CHART_PALETTE, CHART_AXIS, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_LABEL_STYLE } from '@/data/chartColors';
 
 interface GenreBarChartProps {
   data: GenreStat[];
 }
 
-const COLORS = ['#6366f1', '#818cf8', '#a78bfa', '#c4b5fd', '#6366f1', '#818cf8', '#a78bfa', '#c4b5fd', '#6366f1', '#818cf8'];
-
 export function GenreBarChart({ data }: GenreBarChartProps) {
   return (
-    <div className="bg-surface rounded-xl border border-surface-lighter p-5">
-      <h3 className="text-lg font-semibold text-text-primary mb-4">Genres Watched</h3>
+    <div className="bg-surface-container rounded-xl border border-outline-variant p-5">
+      <h3 className="text-lg font-semibold text-on-surface mb-4">Genres Watched</h3>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={data} layout="vertical" margin={{ left: 60 }}>
-          <XAxis type="number" stroke="#6b6985" fontSize={12} />
-          <YAxis type="category" dataKey="genre" stroke="#6b6985" fontSize={12} width={80} />
+          <XAxis type="number" stroke={CHART_AXIS} fontSize={12} />
+          <YAxis type="category" dataKey="genre" stroke={CHART_AXIS} fontSize={12} width={80} />
           <Tooltip
-            contentStyle={{ backgroundColor: '#1e1b2e', border: '1px solid #363352', borderRadius: '8px', color: '#f1f0f7' }}
-            labelStyle={{ color: '#a5a3b7' }}
+            contentStyle={CHART_TOOLTIP_CONTENT_STYLE}
+            labelStyle={CHART_TOOLTIP_LABEL_STYLE}
           />
           <Bar dataKey="count" radius={[0, 4, 4, 0]}>
             {data.map((_, index) => (
-              <Cell key={index} fill={COLORS[index % COLORS.length]} />
+              <Cell key={index} fill={CHART_PALETTE[index % CHART_PALETTE.length]} />
             ))}
           </Bar>
         </BarChart>

--- a/front/src/components/stats/MonthlyHistoryChart.tsx
+++ b/front/src/components/stats/MonthlyHistoryChart.tsx
@@ -1,5 +1,6 @@
 import { XAxis, YAxis, Tooltip, ResponsiveContainer, Area, AreaChart } from 'recharts';
 import type { MonthlyHistory } from '@/types/stats';
+import { CHART_PRIMARY, CHART_AXIS, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_LABEL_STYLE } from '@/data/chartColors';
 
 interface MonthlyHistoryChartProps {
   data: MonthlyHistory[];
@@ -7,23 +8,23 @@ interface MonthlyHistoryChartProps {
 
 export function MonthlyHistoryChart({ data }: MonthlyHistoryChartProps) {
   return (
-    <div className="bg-surface rounded-xl border border-surface-lighter p-5">
-      <h3 className="text-lg font-semibold text-text-primary mb-4">Monthly Activity</h3>
+    <div className="bg-surface-container rounded-xl border border-outline-variant p-5">
+      <h3 className="text-lg font-semibold text-on-surface mb-4">Monthly Activity</h3>
       <ResponsiveContainer width="100%" height={300}>
         <AreaChart data={data}>
           <defs>
             <linearGradient id="colorCount" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+              <stop offset="5%" stopColor={CHART_PRIMARY} stopOpacity={0.3} />
+              <stop offset="95%" stopColor={CHART_PRIMARY} stopOpacity={0} />
             </linearGradient>
           </defs>
-          <XAxis dataKey="month" stroke="#6b6985" fontSize={12} />
-          <YAxis stroke="#6b6985" fontSize={12} />
+          <XAxis dataKey="month" stroke={CHART_AXIS} fontSize={12} />
+          <YAxis stroke={CHART_AXIS} fontSize={12} />
           <Tooltip
-            contentStyle={{ backgroundColor: '#1e1b2e', border: '1px solid #363352', borderRadius: '8px', color: '#f1f0f7' }}
-            labelStyle={{ color: '#a5a3b7' }}
+            contentStyle={CHART_TOOLTIP_CONTENT_STYLE}
+            labelStyle={CHART_TOOLTIP_LABEL_STYLE}
           />
-          <Area type="monotone" dataKey="count" stroke="#6366f1" fill="url(#colorCount)" strokeWidth={2} />
+          <Area type="monotone" dataKey="count" stroke={CHART_PRIMARY} fill="url(#colorCount)" strokeWidth={2} />
         </AreaChart>
       </ResponsiveContainer>
     </div>

--- a/front/src/components/stats/RatingHistogram.tsx
+++ b/front/src/components/stats/RatingHistogram.tsx
@@ -1,5 +1,6 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import type { RatingDistribution } from '@/types/stats';
+import { CHART_PRIMARY, CHART_AXIS, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_LABEL_STYLE } from '@/data/chartColors';
 
 interface RatingHistogramProps {
   data: RatingDistribution[];
@@ -7,19 +8,19 @@ interface RatingHistogramProps {
 
 export function RatingHistogram({ data }: RatingHistogramProps) {
   return (
-    <div className="bg-surface rounded-xl border border-surface-lighter p-5">
-      <h3 className="text-lg font-semibold text-text-primary mb-4">Rating Distribution</h3>
+    <div className="bg-surface-container rounded-xl border border-outline-variant p-5">
+      <h3 className="text-lg font-semibold text-on-surface mb-4">Rating Distribution</h3>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={data}>
-          <XAxis dataKey="score" stroke="#6b6985" fontSize={12} />
-          <YAxis stroke="#6b6985" fontSize={12} />
+          <XAxis dataKey="score" stroke={CHART_AXIS} fontSize={12} />
+          <YAxis stroke={CHART_AXIS} fontSize={12} />
           <Tooltip
-            contentStyle={{ backgroundColor: '#1e1b2e', border: '1px solid #363352', borderRadius: '8px', color: '#f1f0f7' }}
-            labelStyle={{ color: '#a5a3b7' }}
+            contentStyle={CHART_TOOLTIP_CONTENT_STYLE}
+            labelStyle={CHART_TOOLTIP_LABEL_STYLE}
             formatter={(value: number | undefined) => [value ?? 0, 'Count']}
             labelFormatter={(label: React.ReactNode) => `Score: ${label}`}
           />
-          <Bar dataKey="count" fill="#6366f1" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="count" fill={CHART_PRIMARY} radius={[4, 4, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/front/src/components/stats/StatSummaryCard.tsx
+++ b/front/src/components/stats/StatSummaryCard.tsx
@@ -10,14 +10,14 @@ interface StatSummaryCardProps {
 
 export function StatSummaryCard({ icon: Icon, label, value, className }: StatSummaryCardProps) {
   return (
-    <div className={clsx('bg-surface rounded-xl border border-surface-lighter p-5', className)}>
+    <div className={clsx('bg-surface-container rounded-xl border border-outline-variant p-5', className)}>
       <div className="flex items-center gap-3">
-        <div className="p-2.5 rounded-lg bg-primary/10">
+        <div className="p-2.5 rounded-lg bg-primary-container">
           <Icon size={20} className="text-primary" />
         </div>
         <div>
-          <p className="text-sm text-text-secondary">{label}</p>
-          <p className="text-2xl font-bold text-text-primary">{value}</p>
+          <p className="text-sm text-on-surface-variant">{label}</p>
+          <p className="text-2xl font-bold text-on-surface">{value}</p>
         </div>
       </div>
     </div>

--- a/front/src/components/stats/TopStudiosChart.tsx
+++ b/front/src/components/stats/TopStudiosChart.tsx
@@ -1,23 +1,22 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import type { StudioStat } from '@/types/stats';
+import { CHART_PALETTE, CHART_AXIS, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_LABEL_STYLE } from '@/data/chartColors';
 
 interface TopStudiosChartProps {
   data: StudioStat[];
 }
 
-const COLORS = ['#a78bfa', '#818cf8', '#6366f1', '#c4b5fd', '#4f46e5', '#a78bfa'];
-
 export function TopStudiosChart({ data }: TopStudiosChartProps) {
   return (
-    <div className="bg-surface rounded-xl border border-surface-lighter p-5">
-      <h3 className="text-lg font-semibold text-text-primary mb-4">Top Studios</h3>
+    <div className="bg-surface-container rounded-xl border border-outline-variant p-5">
+      <h3 className="text-lg font-semibold text-on-surface mb-4">Top Studios</h3>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={data} layout="vertical" margin={{ left: 80 }}>
-          <XAxis type="number" stroke="#6b6985" fontSize={12} />
-          <YAxis type="category" dataKey="studio" stroke="#6b6985" fontSize={12} width={100} />
+          <XAxis type="number" stroke={CHART_AXIS} fontSize={12} />
+          <YAxis type="category" dataKey="studio" stroke={CHART_AXIS} fontSize={12} width={100} />
           <Tooltip
-            contentStyle={{ backgroundColor: '#1e1b2e', border: '1px solid #363352', borderRadius: '8px', color: '#f1f0f7' }}
-            labelStyle={{ color: '#a5a3b7' }}
+            contentStyle={CHART_TOOLTIP_CONTENT_STYLE}
+            labelStyle={CHART_TOOLTIP_LABEL_STYLE}
             formatter={(value: number | undefined, name: string | undefined) => {
               const v = value ?? 0;
               if (name === 'avgScore') return [v.toFixed(1), 'Avg Score'];
@@ -26,7 +25,7 @@ export function TopStudiosChart({ data }: TopStudiosChartProps) {
           />
           <Bar dataKey="count" radius={[0, 4, 4, 0]}>
             {data.map((_, index) => (
-              <Cell key={index} fill={COLORS[index % COLORS.length]} />
+              <Cell key={index} fill={CHART_PALETTE[index % CHART_PALETTE.length]} />
             ))}
           </Bar>
         </BarChart>

--- a/front/src/data/chartColors.ts
+++ b/front/src/data/chartColors.ts
@@ -1,0 +1,40 @@
+/**
+ * MD3 design-token hex values for recharts components.
+ *
+ * recharts does not accept CSS custom properties (`var(--color-*)`) in
+ * fill / stroke / style props, so we duplicate the resolved hex values here.
+ * If the MD3 palette in `index.css` is updated, these constants must be
+ * updated accordingly.
+ */
+
+import type { CSSProperties } from 'react';
+
+/* ── single-series colour ── */
+/** --color-primary */
+export const CHART_PRIMARY = '#c0c1ff';
+
+/* ── axis / grid colour ── */
+/** --color-outline */
+export const CHART_AXIS = '#918f9a';
+
+/* ── tooltip shared styles ── */
+export const CHART_TOOLTIP_CONTENT_STYLE: CSSProperties = {
+  backgroundColor: '#1f1f25', // --color-surface-container
+  border: '1px solid #46464f', // --color-outline-variant
+  borderRadius: '8px',
+  color: '#e4e1e9', // --color-on-surface
+};
+
+export const CHART_TOOLTIP_LABEL_STYLE: CSSProperties = {
+  color: '#c8c5d0', // --color-on-surface-variant
+};
+
+/* ── multi-series palette (6 colours) ── */
+export const CHART_PALETTE = [
+  '#c0c1ff', // primary
+  '#e9b9d3', // tertiary
+  '#c6c4dd', // secondary
+  '#e1e0ff', // on-primary-container
+  '#ffd8ec', // on-tertiary-container
+  '#e2e0f9', // on-secondary-container
+] as const;


### PR DESCRIPTION
## Summary
- recharts가 CSS 변수(`var()`)를 지원하지 않으므로 MD3 hex 값을 export하는 `front/src/data/chartColors.ts` 상수 파일 생성
- 4개 차트 컴포넌트(`GenreBarChart`, `RatingHistogram`, `MonthlyHistoryChart`, `TopStudiosChart`)의 하드코딩된 hex 색상을 상수 파일 import로 교체
- 5개 stats 컴포넌트의 구 Tailwind 토큰(`bg-surface`, `border-surface-lighter`, `text-text-primary`, `text-text-secondary`, `bg-primary/10`)을 MD3 토큰(`bg-surface-container`, `border-outline-variant`, `text-on-surface`, `text-on-surface-variant`, `bg-primary-container`)으로 교체

## Test plan
- [x] `components/stats/` 내 기존 hex 값(`#6366f1`, `#818cf8` 등) grep 검출 0건
- [x] `components/stats/` 내 구 Tailwind 토큰(`surface-lighter`, `text-text-primary`, `text-text-secondary`) grep 검출 0건
- [x] `npm run build` 성공 (TypeScript 컴파일 오류 없음)
- [x] `npm run lint` 기존 오류만 존재, 신규 오류 0건

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)