### PR TITLE
feat(front): SearchAnimePage 실제 API 연동

### DIFF
--- a/front/src/components/filters/FilterBar.tsx
+++ b/front/src/components/filters/FilterBar.tsx
@@ -3,7 +3,7 @@ import { SearchInput } from './SearchInput';
 import { FilterDropdown } from './FilterDropdown';
 import { SortSelector } from './SortSelector';
 import { Button } from '@/components/ui/Button';
-import { GENRES, FORMATS, SEASONS } from '@/data/constants';
+import { GENRES, FORMATS } from '@/data/constants';
 import type { FilterState } from '@/hooks/useFilterState';
 
 interface FilterBarProps {
@@ -13,13 +13,8 @@ interface FilterBarProps {
   resultCount: number;
 }
 
-const yearOptions = Array.from({ length: 30 }, (_, i) => {
-  const year = new Date().getFullYear() - i;
-  return { value: year.toString(), label: year.toString() };
-});
-
 export function FilterBar({ filters, onFilterChange, onReset, resultCount }: FilterBarProps) {
-  const hasActiveFilters = filters.search || filters.genre || filters.format || filters.season || filters.year;
+  const hasActiveFilters = filters.search || filters.genre || filters.format;
 
   return (
     <div className="space-y-4">
@@ -34,32 +29,20 @@ export function FilterBar({ filters, onFilterChange, onReset, resultCount }: Fil
           label="Genre"
           value={filters.genre}
           onChange={v => onFilterChange('genre', v)}
-          options={GENRES.map(g => ({ value: g, label: g }))}
+          options={GENRES}
         />
         <FilterDropdown
           label="Format"
           value={filters.format}
           onChange={v => onFilterChange('format', v)}
-          options={FORMATS.map(f => ({ value: f, label: f }))}
-        />
-        <FilterDropdown
-          label="Season"
-          value={filters.season}
-          onChange={v => onFilterChange('season', v)}
-          options={SEASONS}
-        />
-        <FilterDropdown
-          label="Year"
-          value={filters.year}
-          onChange={v => onFilterChange('year', v)}
-          options={yearOptions}
+          options={FORMATS}
         />
         {hasActiveFilters && (
-          <Button variant="ghost" size="sm" onClick={onReset} className="text-text-muted">
+          <Button variant="ghost" size="sm" onClick={onReset} className="text-on-surface-variant">
             <RotateCcw size={14} /> Reset
           </Button>
         )}
-        <span className="text-sm text-text-muted ml-auto">{resultCount} results</span>
+        <span className="text-sm text-on-surface-variant ml-auto">{resultCount} results</span>
       </div>
     </div>
   );

--- a/front/src/components/ui/Pagination.tsx
+++ b/front/src/components/ui/Pagination.tsx
@@ -1,0 +1,83 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import clsx from 'clsx';
+
+interface PaginationProps {
+  currentPage: number;
+  lastPage: number;
+  hasNextPage: boolean;
+  onPageChange: (page: number) => void;
+}
+
+function getPageNumbers(current: number, last: number): (number | 'ellipsis')[] {
+  if (last <= 7) {
+    return Array.from({ length: last }, (_, i) => i + 1);
+  }
+
+  const pages: (number | 'ellipsis')[] = [1];
+
+  if (current <= 4) {
+    pages.push(2, 3, 4, 5, 'ellipsis', last);
+  } else if (current >= last - 3) {
+    pages.push('ellipsis', last - 4, last - 3, last - 2, last - 1, last);
+  } else {
+    pages.push('ellipsis', current - 1, current, current + 1, 'ellipsis', last);
+  }
+
+  return pages;
+}
+
+export function Pagination({ currentPage, lastPage, hasNextPage, onPageChange }: PaginationProps) {
+  if (lastPage <= 1) return null;
+
+  const pages = getPageNumbers(currentPage, lastPage);
+
+  const handlePageChange = (page: number) => {
+    onPageChange(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <nav className="flex items-center justify-center gap-1 pt-8" aria-label="Pagination">
+      <button
+        onClick={() => handlePageChange(currentPage - 1)}
+        disabled={currentPage <= 1}
+        className="inline-flex items-center justify-center w-9 h-9 rounded-lg text-on-surface-variant hover:bg-surface-container-high disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        aria-label="Previous page"
+      >
+        <ChevronLeft size={18} />
+      </button>
+
+      {pages.map((page, i) =>
+        page === 'ellipsis' ? (
+          <span key={`ellipsis-${i}`} className="w-9 h-9 inline-flex items-center justify-center text-on-surface-variant text-sm">
+            ...
+          </span>
+        ) : (
+          <button
+            key={page}
+            onClick={() => handlePageChange(page)}
+            className={clsx(
+              'inline-flex items-center justify-center w-9 h-9 rounded-lg text-sm font-medium transition-colors',
+              page === currentPage
+                ? 'bg-primary text-white'
+                : 'text-on-surface-variant hover:bg-surface-container-high'
+            )}
+            aria-label={`Page ${page}`}
+            aria-current={page === currentPage ? 'page' : undefined}
+          >
+            {page}
+          </button>
+        )
+      )}
+
+      <button
+        onClick={() => handlePageChange(currentPage + 1)}
+        disabled={!hasNextPage}
+        className="inline-flex items-center justify-center w-9 h-9 rounded-lg text-on-surface-variant hover:bg-surface-container-high disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        aria-label="Next page"
+      >
+        <ChevronRight size={18} />
+      </button>
+    </nav>
+  );
+}

--- a/front/src/data/constants.ts
+++ b/front/src/data/constants.ts
@@ -1,26 +1,47 @@
-export const GENRES = [
-  'Action', 'Adventure', 'Comedy', 'Drama', 'Fantasy',
-  'Horror', 'Mystery', 'Romance', 'Sci-Fi', 'Slice of Life',
-  'Sports', 'Supernatural', 'Thriller', 'Mecha', 'Music',
-] as const;
-
-export const SEASONS: { value: string; label: string }[] = [
-  { value: 'winter', label: 'Winter' },
-  { value: 'spring', label: 'Spring' },
-  { value: 'summer', label: 'Summer' },
-  { value: 'fall', label: 'Fall' },
+export const GENRES: { value: string; label: string }[] = [
+  { value: '1', label: 'Action' },
+  { value: '2', label: 'Adventure' },
+  { value: '4', label: 'Comedy' },
+  { value: '8', label: 'Drama' },
+  { value: '10', label: 'Fantasy' },
+  { value: '14', label: 'Horror' },
+  { value: '18', label: 'Mecha' },
+  { value: '19', label: 'Music' },
+  { value: '7', label: 'Mystery' },
+  { value: '22', label: 'Romance' },
+  { value: '24', label: 'Sci-Fi' },
+  { value: '36', label: 'Slice of Life' },
+  { value: '30', label: 'Sports' },
+  { value: '37', label: 'Supernatural' },
+  { value: '41', label: 'Suspense' },
 ];
 
-export const FORMATS = ['TV', 'Movie', 'OVA', 'ONA', 'Special', 'Music'] as const;
+export const FORMATS: { value: string; label: string }[] = [
+  { value: 'tv', label: 'TV' },
+  { value: 'movie', label: 'Movie' },
+  { value: 'ova', label: 'OVA' },
+  { value: 'ona', label: 'ONA' },
+  { value: 'special', label: 'Special' },
+  { value: 'music', label: 'Music' },
+];
 
-export const SORT_OPTIONS = [
+export const SORT_OPTIONS: { value: string; label: string }[] = [
   { value: 'score-desc', label: 'Score (High to Low)' },
   { value: 'score-asc', label: 'Score (Low to High)' },
   { value: 'title-asc', label: 'Title (A-Z)' },
   { value: 'title-desc', label: 'Title (Z-A)' },
   { value: 'popularity-asc', label: 'Most Popular' },
   { value: 'newest', label: 'Newest First' },
-] as const;
+];
+
+export const SORT_PARAM_MAP: Record<string, { orderBy: string; sort: string }> = {
+  'score-desc': { orderBy: 'score', sort: 'desc' },
+  'score-asc': { orderBy: 'score', sort: 'asc' },
+  'title-asc': { orderBy: 'title', sort: 'asc' },
+  'title-desc': { orderBy: 'title', sort: 'desc' },
+  'popularity-asc': { orderBy: 'popularity', sort: 'asc' },
+  'newest': { orderBy: 'start_date', sort: 'desc' },
+};
 
 export const WATCH_STATUSES = [
   'Watching', 'Completed', 'Plan to Watch', 'Dropped', 'On Hold',

--- a/front/src/hooks/useAnimeSearch.ts
+++ b/front/src/hooks/useAnimeSearch.ts
@@ -6,7 +6,7 @@ import type { SearchParams } from '@/api/animeApi';
 
 const DEBOUNCE_MS = 300;
 
-export function useAnimeSearch(params: SearchParams) {
+export function useAnimeSearch(params: SearchParams, key?: number) {
   const { q, type, genres, orderBy, sort, page, limit } = params;
   const [data, setData] = useState<Anime[]>([]);
   const [pagination, setPagination] = useState<Pagination | null>(null);
@@ -42,7 +42,7 @@ export function useAnimeSearch(params: SearchParams) {
     return () => {
       clearTimeout(timer);
     };
-  }, [q, type, genres, orderBy, sort, page, limit]);
+  }, [q, type, genres, orderBy, sort, page, limit, key]);
 
   useEffect(() => {
     return () => {

--- a/front/src/hooks/useFilterState.ts
+++ b/front/src/hooks/useFilterState.ts
@@ -1,12 +1,11 @@
-import { useState, useMemo } from 'react';
-import type { Anime } from '@/types/anime';
+import { useState } from 'react';
+import { SORT_PARAM_MAP } from '@/data/constants';
+import type { SearchParams } from '@/api/animeApi';
 
 export interface FilterState {
   search: string;
   genre: string;
   format: string;
-  season: string;
-  year: string;
   sort: string;
 }
 
@@ -14,12 +13,10 @@ const defaultFilters: FilterState = {
   search: '',
   genre: '',
   format: '',
-  season: '',
-  year: '',
   sort: 'score-desc',
 };
 
-export function useFilterState(animeList: Anime[]) {
+export function useFilterState() {
   const [filters, setFilters] = useState<FilterState>(defaultFilters);
 
   const updateFilter = (key: keyof FilterState, value: string) => {
@@ -28,52 +25,18 @@ export function useFilterState(animeList: Anime[]) {
 
   const resetFilters = () => setFilters(defaultFilters);
 
-  const filteredAnime = useMemo(() => {
-    let result = [...animeList];
+  const buildSearchParams = (page: number): SearchParams => {
+    const sortMapping = SORT_PARAM_MAP[filters.sort];
+    return {
+      q: filters.search || undefined,
+      genres: filters.genre || undefined,
+      type: filters.format || undefined,
+      orderBy: sortMapping?.orderBy,
+      sort: sortMapping?.sort,
+      page,
+      limit: 24,
+    };
+  };
 
-    if (filters.search) {
-      const q = filters.search.toLowerCase();
-      result = result.filter(a =>
-        a.title.toLowerCase().includes(q) ||
-        a.title_japanese?.toLowerCase().includes(q)
-      );
-    }
-    if (filters.genre) {
-      result = result.filter(a => a.genres.some(g => g.name === filters.genre));
-    }
-    if (filters.format) {
-      result = result.filter(a => a.type === filters.format);
-    }
-    if (filters.season) {
-      result = result.filter(a => a.season?.toLowerCase() === filters.season);
-    }
-    if (filters.year) {
-      result = result.filter(a => a.year?.toString() === filters.year);
-    }
-
-    switch (filters.sort) {
-      case 'score-desc':
-        result.sort((a, b) => b.score - a.score);
-        break;
-      case 'score-asc':
-        result.sort((a, b) => a.score - b.score);
-        break;
-      case 'title-asc':
-        result.sort((a, b) => a.title.localeCompare(b.title));
-        break;
-      case 'title-desc':
-        result.sort((a, b) => b.title.localeCompare(a.title));
-        break;
-      case 'popularity-asc':
-        result.sort((a, b) => a.popularity - b.popularity);
-        break;
-      case 'newest':
-        result.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
-        break;
-    }
-
-    return result;
-  }, [animeList, filters]);
-
-  return { filters, updateFilter, resetFilters, filteredAnime };
+  return { filters, updateFilter, resetFilters, buildSearchParams };
 }

--- a/front/src/pages/SearchAnimePage.tsx
+++ b/front/src/pages/SearchAnimePage.tsx
@@ -1,39 +1,84 @@
 import { useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { FilterBar } from '@/components/filters/FilterBar';
 import { AnimeGrid } from '@/components/anime/AnimeGrid';
 import { RatingModal } from '@/components/rating/RatingModal';
+import { Spinner } from '@/components/ui/Spinner';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { Button } from '@/components/ui/Button';
+import { Pagination } from '@/components/ui/Pagination';
 import { useFilterState } from '@/hooks/useFilterState';
-import { mockAnime } from '@/data/mockAnime';
+import { useAnimeSearch } from '@/hooks/useAnimeSearch';
 import type { Anime } from '@/types/anime';
-import type { WatchStatus } from '@/types/rating';
 
 export function SearchAnimePage() {
-  const { filters, updateFilter, resetFilters, filteredAnime } = useFilterState(mockAnime);
+  const { filters, updateFilter, resetFilters, buildSearchParams } = useFilterState();
+  const [page, setPage] = useState(1);
+  const [retryKey, setRetryKey] = useState(0);
   const [ratingAnime, setRatingAnime] = useState<Anime | null>(null);
 
-  const handleRate = (anime: Anime) => setRatingAnime(anime);
-  const handleRatingSubmit = (_animeId: number, _score: number, _status: WatchStatus) => {
-    // Mock: would save
+  const searchParams = buildSearchParams(page);
+  const { data, pagination, isLoading, error } = useAnimeSearch(searchParams, retryKey);
+
+  const resultCount = pagination?.items?.total ?? data.length;
+
+  const handleFilterChange = (key: Parameters<typeof updateFilter>[0], value: string) => {
+    updateFilter(key, value);
+    setPage(1);
   };
+
+  const handleReset = () => {
+    resetFilters();
+    setPage(1);
+  };
+
+  const handleRate = (anime: Anime) => setRatingAnime(anime);
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <h1 className="text-3xl font-bold text-text-primary mb-8">Search Anime</h1>
+      <h1 className="text-3xl font-bold text-on-surface mb-8">Search Anime</h1>
       <div className="space-y-6">
         <FilterBar
           filters={filters}
-          onFilterChange={updateFilter}
-          onReset={resetFilters}
-          resultCount={filteredAnime.length}
+          onFilterChange={handleFilterChange}
+          onReset={handleReset}
+          resultCount={resultCount}
         />
-        <AnimeGrid anime={filteredAnime} onRate={handleRate} />
+
+        {error ? (
+          <EmptyState
+            icon={AlertTriangle}
+            title="Failed to load anime"
+            description={error.message}
+            action={
+              <Button variant="secondary" onClick={() => setRetryKey(k => k + 1)}>
+                Retry
+              </Button>
+            }
+          />
+        ) : isLoading && data.length === 0 ? (
+          <Spinner size="lg" className="py-20" />
+        ) : (
+          <div className={isLoading ? 'opacity-50 pointer-events-none' : undefined}>
+            <AnimeGrid anime={data} onRate={handleRate} />
+          </div>
+        )}
+
+        {!error && data.length > 0 && pagination && (
+          <Pagination
+            currentPage={pagination.current_page}
+            lastPage={pagination.last_visible_page}
+            hasNextPage={pagination.has_next_page}
+            onPageChange={setPage}
+          />
+        )}
       </div>
 
       <RatingModal
         anime={ratingAnime}
         isOpen={!!ratingAnime}
         onClose={() => setRatingAnime(null)}
-        onSubmit={handleRatingSubmit}
+        onSubmit={() => {/* Mock: would save */}}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- `SearchAnimePage`의 `mockAnime` 클라이언트 필터링을 백엔드 `GET /api/anime` 호출로 전환하여 서버사이드 필터링 + 페이지네이션 지원
- `GENRES`를 MAL genre ID 기반으로 변환하고 `SORT_PARAM_MAP`을 추가하여 필터 값 → API 파라미터 매핑
- `useFilterState`를 API 파라미터 빌더(`buildSearchParams`)로 리팩토링하고, 백엔드 미지원 Season/Year 필터 제거
- 로딩 스피너, 에러 상태(재시도 버튼), 페이지네이션 UI(`Pagination` 컴포넌트 신규) 추가
- FilterBar의 레거시 토큰(`text-text-muted`)을 MD3 토큰(`text-on-surface-variant`)으로 마이그레이션

## Test plan
- [ ] `cd front && npm run build` 성공 (TypeScript 에러 없음)
- [ ] `npm run lint` 통과 (변경 파일 기준)
- [ ] 검색어 입력 시 300ms 디바운스 후 API 호출로 결과 갱신
- [ ] 장르/포맷/정렬 필터 변경 시 API 재호출 + 페이지 1로 리셋
- [ ] 페이지네이션 버튼으로 다음/이전 페이지 탐색 가능
- [ ] 에러 발생 시 에러 메시지 + Retry 버튼 표시
- [ ] 결과 없을 때 빈 상태 메시지 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)